### PR TITLE
CSP-1635: AddedLegalEntityEvent - Handle Null Account Edge Case

### DIFF
--- a/src/SFA.DAS.PR.Jobs.MessageHandlers.TestHarness/RaiseEventService.cs
+++ b/src/SFA.DAS.PR.Jobs.MessageHandlers.TestHarness/RaiseEventService.cs
@@ -43,7 +43,7 @@ public class RaiseEventService(IMessageSession _messageSession, IHostApplication
     {
         var userRef = Guid.NewGuid();
         const string userName = "Bob Loblaw";
-        const long accountId = 10;
+        const long accountId = 1;
         const string accountPublicHashedId = "ACCPUB";
         const string originalAccountName = "Account Name";
         const string updatedAccountName = "New Account Name";

--- a/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/AddedLegalEntityEventHandlerTests.cs
+++ b/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/AddedLegalEntityEventHandlerTests.cs
@@ -1,12 +1,10 @@
 ﻿using System.Text.Json;
-using AutoFixture;
 using AutoFixture.NUnit3;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
 using Moq;
 using SFA.DAS.EmployerAccounts.Messages.Events;
-using SFA.DAS.PR.Data.Entities;
 using SFA.DAS.PR.Jobs.Infrastructure;
 using SFA.DAS.PR.Jobs.MessageHandlers.EmployerAccounts;
 using SFA.DAS.PR.Jobs.Models;
@@ -18,7 +16,7 @@ namespace SFA.DAS.PR.Jobs.UnitTests.MessageHandlers;
 public class AddedLegalEntityEventHandlerTests
 {
     [Test, AutoData]
-    public async Task AddedLegalEntityEventHandlerTests_Handle_AccountLegalEntityExists_AddsAuditOnly(AddedLegalEntityEvent message, string messageId)
+    public async Task Handle_AccountLegalEntityExists_AddsAuditOnly(AddedLegalEntityEvent message, string messageId)
     {
         using var dbContext = DbContextHelper
             .CreateInMemoryDbContext()
@@ -50,7 +48,7 @@ public class AddedLegalEntityEventHandlerTests
     }
 
     [Test, AutoData]
-    public async Task AddedLegalEntityEventHandlerTests_Handle_ProviderRelationshipsAccountIsNull_AddAccount(AddedLegalEntityEvent message, AccountDetails accountDetails, string messageId)
+    public async Task Handle_ProviderRelationshipsAccountIsNull_AddAccount(AddedLegalEntityEvent message, AccountDetails accountDetails, string messageId)
     {
         using var dbContext = DbContextHelper
             .CreateInMemoryDbContext()
@@ -83,7 +81,7 @@ public class AddedLegalEntityEventHandlerTests
     }
 
     [Test, AutoData]
-    public async Task AddedLegalEntityEventHandlerTests_Handle_AccountLegalEntityDoesNotExists_CreatesAccountLegalEntity(AddedLegalEntityEvent message, string messageId)
+    public async Task Handle_AccountLegalEntityDoesNotExists_CreatesAccountLegalEntity(AddedLegalEntityEvent message, string messageId)
     {
         using var dbContext = DbContextHelper.CreateInMemoryDbContext()
             .AddAccount(AccountData.Create(message.AccountId))

--- a/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/AddedLegalEntityEventHandlerTests.cs
+++ b/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/AddedLegalEntityEventHandlerTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Text.Json;
+using AutoFixture;
 using AutoFixture.NUnit3;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
 using Moq;
 using SFA.DAS.EmployerAccounts.Messages.Events;
+using SFA.DAS.PR.Data.Entities;
 using SFA.DAS.PR.Jobs.Infrastructure;
 using SFA.DAS.PR.Jobs.MessageHandlers.EmployerAccounts;
 using SFA.DAS.PR.Jobs.Models;
@@ -83,7 +85,9 @@ public class AddedLegalEntityEventHandlerTests
     [Test, AutoData]
     public async Task AddedLegalEntityEventHandlerTests_Handle_AccountLegalEntityDoesNotExists_CreatesAccountLegalEntity(AddedLegalEntityEvent message, string messageId)
     {
-        using var dbContext = DbContextHelper.CreateInMemoryDbContext();
+        using var dbContext = DbContextHelper.CreateInMemoryDbContext()
+            .AddAccount(AccountData.Create(message.AccountId))
+            .PersistChanges();
 
         IEmployerAccountsApiClient employerAccountsClient = Mock.Of<IEmployerAccountsApiClient>();
 

--- a/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/ChangedAccountNameEventHandlerTests.cs
+++ b/src/SFA.DAS.PR.Jobs.UnitTests/MessageHandlers/ChangedAccountNameEventHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using AutoFixture;
+using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/src/SFA.DAS.PR.Jobs/Extensions/AddServiceRegistrationsExtension.cs
+++ b/src/SFA.DAS.PR.Jobs/Extensions/AddServiceRegistrationsExtension.cs
@@ -16,11 +16,23 @@ public static class AddServiceRegistrationsExtension
         services
             .RegisterServices()
             .AddHttpClient()
+            .RegisterEmployerAccountsApiClient(configuration)
             .RegisterRoatpServiceApiClient(configuration)
             .RegisterRecruitServiceApiClient(configuration)
             .RegisterPasAccountApiClient(configuration)
             .RegisterCommitmentsV2ApiClient(configuration)
             .BindConfiguration(configuration);
+
+        return services;
+    }
+
+    public static IServiceCollection RegisterEmployerAccountsApiClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        var employerAccountsApiConfiguration = configuration.GetSection("EmployerAccountsApiConfiguration").Get<InnerApiConfiguration>();
+
+        services.AddRefitClient<IEmployerAccountsApiClient>()
+                .ConfigureHttpClient(c => c.BaseAddress = new Uri(employerAccountsApiConfiguration!.Url))
+                .AddHttpMessageHandler(() => new InnerApiAuthenticationHeaderHandler(new AzureClientCredentialHelper(), employerAccountsApiConfiguration!.Identifier));
 
         return services;
     }

--- a/src/SFA.DAS.PR.Jobs/Infrastructure/IEmployerAccountsApiClient.cs
+++ b/src/SFA.DAS.PR.Jobs/Infrastructure/IEmployerAccountsApiClient.cs
@@ -1,0 +1,10 @@
+﻿using Refit;
+using SFA.DAS.PR.Jobs.OuterApi.Responses;
+
+namespace SFA.DAS.PR.Jobs.Infrastructure;
+
+public interface IEmployerAccountsApiClient
+{
+    [Get("/api/accounts/{accountId}")]
+    Task<AccountDetails> GetAccount(long accountId, CancellationToken cancellationToken);
+}

--- a/src/SFA.DAS.PR.Jobs/MessageHandlers/EmployerAccounts/AddedLegalEntityEventHandler.cs
+++ b/src/SFA.DAS.PR.Jobs/MessageHandlers/EmployerAccounts/AddedLegalEntityEventHandler.cs
@@ -1,47 +1,80 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
 using SFA.DAS.EmployerAccounts.Messages.Events;
 using SFA.DAS.PR.Data;
 using SFA.DAS.PR.Data.Entities;
+using SFA.DAS.PR.Jobs.Infrastructure;
 using SFA.DAS.PR.Jobs.Models;
 
 namespace SFA.DAS.PR.Jobs.MessageHandlers.EmployerAccounts;
-public class AddedLegalEntityEventHandler(IProviderRelationshipsDataContext _providerRelationshipsDataContext, ILogger<AddedLegalEntityEventHandler> _logger) : IHandleMessages<AddedLegalEntityEvent>
+
+public class AddedLegalEntityEventHandler(
+    ILogger<AddedLegalEntityEventHandler> _logger,
+    IProviderRelationshipsDataContext _providerRelationshipsDataContext,
+    IEmployerAccountsApiClient _employerAccountsApiClient 
+) : IHandleMessages<AddedLegalEntityEvent>
 {
     public const string AccountLegalEntityAlreadyExistsFailureReason = "Account legal entity already exists";
 
     public async Task Handle(AddedLegalEntityEvent message, IMessageHandlerContext context)
     {
-        var accountLegalEntity = await _providerRelationshipsDataContext
+        AccountLegalEntity? accountLegalEntity = await _providerRelationshipsDataContext
             .AccountLegalEntities
             .FirstOrDefaultAsync(a => a.AccountId == message.AccountId && a.Id == message.AccountLegalEntityId, context.CancellationToken);
 
         if (accountLegalEntity != null)
         {
             _logger.LogWarning("Legal entity with Id:{LegalEntityId} already exists", message.LegalEntityId);
+
             JobAudit jobAudit = new(
-                nameof(AddedLegalEntityEventHandler),
-                new EventHandlerJobInfo<AddedLegalEntityEvent>(context.MessageId, message, false, AccountLegalEntityAlreadyExistsFailureReason));
+                nameof(AddedLegalEntityEventHandler), 
+                new EventHandlerJobInfo<AddedLegalEntityEvent>(context.MessageId, message, false, AccountLegalEntityAlreadyExistsFailureReason)
+            );
+
             _providerRelationshipsDataContext.JobAudits.Add(jobAudit);
         }
         else
         {
-            _providerRelationshipsDataContext
-                .AccountLegalEntities
-                .Add(new()
+            Account? providerRelationshipsAccount = await _providerRelationshipsDataContext.Accounts.FirstOrDefaultAsync(a => a.Id == message.AccountId, context.CancellationToken);
+
+            if(providerRelationshipsAccount is null)
+            {
+                var accountResponse = await _employerAccountsApiClient.GetAccount(message.AccountId, context.CancellationToken);
+
+                providerRelationshipsAccount = new Account()
                 {
-                    Id = message.AccountLegalEntityId,
-                    AccountId = message.AccountId,
-                    PublicHashedId = message.AccountLegalEntityPublicHashedId,
-                    Name = message.OrganisationName,
-                    Created = message.Created
-                });
-            _providerRelationshipsDataContext
-                .JobAudits
-                .Add(new(nameof(AddedLegalEntityEventHandler),
-                    new EventHandlerJobInfo<AddedLegalEntityEvent>(context.MessageId, message, true, null)));
+                    Id = message.AccountId,
+                    HashedId = accountResponse.HashedAccountId,
+                    PublicHashedId = accountResponse.PublicHashedAccountId,
+                    Name = accountResponse.DasAccountName,
+                    Created = DateTime.UtcNow
+                };
+
+                await _providerRelationshipsDataContext.Accounts.AddAsync(providerRelationshipsAccount, context.CancellationToken);
+            }
+
+            var newAccountLegalEntity = new AccountLegalEntity() {
+                Id = message.AccountLegalEntityId,
+                Account = providerRelationshipsAccount!,
+                PublicHashedId = message.AccountLegalEntityPublicHashedId,
+                Name = message.OrganisationName,
+                Created = message.Created
+            };
+
+            await _providerRelationshipsDataContext.AccountLegalEntities.AddAsync(newAccountLegalEntity, context.CancellationToken);
+
+            JobAudit jobAudit = new JobAudit(
+                nameof(AddedLegalEntityEventHandler),
+                new EventHandlerJobInfo<AddedLegalEntityEvent>(context.MessageId, message, true, null)
+            );
+
+            await _providerRelationshipsDataContext.JobAudits.AddAsync(jobAudit, context.CancellationToken);
+
             _logger.LogInformation("Created new legal entity with Id: {LegalEntityId} associated with employer account with Id:{EmployerAccountId}", message.LegalEntityId, message.AccountId);
         }
+
         await _providerRelationshipsDataContext.SaveChangesAsync(context.CancellationToken);
     }
 }

--- a/src/SFA.DAS.PR.Jobs/MessageHandlers/EmployerAccounts/AddedLegalEntityEventHandler.cs
+++ b/src/SFA.DAS.PR.Jobs/MessageHandlers/EmployerAccounts/AddedLegalEntityEventHandler.cs
@@ -52,7 +52,7 @@ public class AddedLegalEntityEventHandler(
                     Created = DateTime.UtcNow
                 };
 
-                await _providerRelationshipsDataContext.Accounts.AddAsync(providerRelationshipsAccount, context.CancellationToken);
+                _providerRelationshipsDataContext.Accounts.Add(providerRelationshipsAccount);
             }
 
             var newAccountLegalEntity = new AccountLegalEntity() {
@@ -63,14 +63,14 @@ public class AddedLegalEntityEventHandler(
                 Created = message.Created
             };
 
-            await _providerRelationshipsDataContext.AccountLegalEntities.AddAsync(newAccountLegalEntity, context.CancellationToken);
+            _providerRelationshipsDataContext.AccountLegalEntities.Add(newAccountLegalEntity);
 
             JobAudit jobAudit = new JobAudit(
                 nameof(AddedLegalEntityEventHandler),
                 new EventHandlerJobInfo<AddedLegalEntityEvent>(context.MessageId, message, true, null)
             );
 
-            await _providerRelationshipsDataContext.JobAudits.AddAsync(jobAudit, context.CancellationToken);
+            _providerRelationshipsDataContext.JobAudits.Add(jobAudit);
 
             _logger.LogInformation("Created new legal entity with Id: {LegalEntityId} associated with employer account with Id:{EmployerAccountId}", message.LegalEntityId, message.AccountId);
         }

--- a/src/SFA.DAS.PR.Jobs/OuterApi/Responses/AccountDetails.cs
+++ b/src/SFA.DAS.PR.Jobs/OuterApi/Responses/AccountDetails.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.PR.Jobs.OuterApi.Responses;
+
+public sealed class AccountDetails
+{
+    public long AccountId { get; set; }
+    public required string HashedAccountId { get; set; }
+    public required string PublicHashedAccountId { get; set; }
+    public required string DasAccountName { get; set; }
+}


### PR DESCRIPTION
- **AddedLegalEntityEvent** - When the associated account does not exist within the provider relationships database, use the **EmployerAccountsApi** to query account details.